### PR TITLE
#324 - [Refactor] 운동 결과 UI 수정

### DIFF
--- a/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringWorkoutResultCells/DuringWorkoutResultSectionCell.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringWorkoutResultCells/DuringWorkoutResultSectionCell.swift
@@ -9,9 +9,8 @@ import UIKit
 
 final class DuringWorkoutResultSectionCell : UITableViewCell {
     static let identifier = "DuringSetTableViewCell"
-    var completionHandler : ((Bool) -> Void)?
-    
     var weightTrainingValue : WeightTraining?
+    
     
     private let backView = UIView().then {
         $0.layer.cornerRadius = 10
@@ -20,11 +19,11 @@ final class DuringWorkoutResultSectionCell : UITableViewCell {
         $0.backgroundColor = .colorFFFFFF
     }
     
-    let workoutTitle = UILabel().then {
+    private let workoutTitle = UILabel().then {
         $0.font = .pretendard(.semiBold, size: 20)
         $0.textColor = .color121212
     }
-    let workoutSectionTableView = UITableView().then {
+    private let workoutSectionTableView = UITableView().then {
         $0.backgroundColor = .colorFFFFFF
         $0.separatorStyle = .none
     }
@@ -38,12 +37,13 @@ final class DuringWorkoutResultSectionCell : UITableViewCell {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        setStyle()
+        setLayout()
+        setComponents()
     }
     override func prepareForReuse() {
         super.prepareForReuse()
-        workoutTitle.text = nil
-//        DuringWorkoutResultSetCell().prepareForReuse()
-    }
+        workoutTitle.text = nil    }
     private func setComponents() {
         workoutSectionTableView.delegate = self
         workoutSectionTableView.dataSource = self
@@ -57,7 +57,7 @@ final class DuringWorkoutResultSectionCell : UITableViewCell {
     private func setLayout() {
         contentView.addSubview(backView)
         backView.addSubviews(workoutTitle, workoutSectionTableView)
-        
+
         backView.snp.makeConstraints {
             $0.top.bottom.equalToSuperview().inset(6)
             $0.leading.trailing.equalToSuperview().inset(14)
@@ -72,27 +72,38 @@ final class DuringWorkoutResultSectionCell : UITableViewCell {
             $0.bottom.equalToSuperview().inset(20)
             $0.leading.trailing.equalToSuperview().inset(11)
         }
+
     }
     func configureCell(_ weightTraining : WeightTraining) {
         workoutTitle.text = weightTraining.weightTraining
+        weightTrainingValue = weightTraining
+        
+        workoutSectionTableView.snp.remakeConstraints {
+            $0.height.equalTo(49 * weightTraining.weightTrainingInfo.count)
+            $0.top.equalTo(workoutTitle.snp.bottom).offset(10)
+            $0.bottom.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(11)
+        }
+
     }
+
 }
 extension DuringWorkoutResultSectionCell : UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return weightTrainingValue?.weightTrainingInfo.count ?? 0
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: DuringWorkoutResultSetCell.identifier, for: indexPath) as? DuringWorkoutResultSetCell else { return UITableViewCell() }
         if let weightTrainingValue = weightTrainingValue {
             cell.configureCell(weightTrainingValue.weightTrainingInfo[indexPath.row])
+            cell.checkCalisthenics(weightTrainingValue)
         }
-//        completionHandler?(true)
         cell.selectionStyle = .none
         return cell
     }
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 49
     }
-    
+
 }

--- a/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringWorkoutResultCells/DuringWorkoutResultSetCell.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringWorkoutResultCells/DuringWorkoutResultSetCell.swift
@@ -16,11 +16,20 @@ final class DuringWorkoutResultSetCell : UITableViewCell {
         $0.layer.borderColor = UIColor.colorE6E0FF.cgColor
         $0.backgroundColor = .colorFFFFFF
     }
-    private let setLabel = UILabel()
+    private let setLabel = UILabel().then {
+        $0.font = .pretendard(.regular, size: 16)
+        $0.textColor = .color363636
+    }
     
-    private let weightLabel = UILabel()
+    private let weightLabel = UILabel().then {
+        $0.font = .pretendard(.regular, size: 16)
+        $0.textColor = .color363636
+    }
     
-    private let countLabel = UILabel()
+    private let countLabel = UILabel().then {
+        $0.font = .pretendard(.regular, size: 16)
+        $0.textColor = .color363636
+    }
     
     override func layoutSubviews() {
         super.layoutSubviews()

--- a/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringWorkoutResultViewController.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringWorkoutResultViewController.swift
@@ -188,25 +188,12 @@ extension DuringWorkoutResultViewController : UITableViewDelegate, UITableViewDa
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: DuringWorkoutResultSectionCell.identifier, for: indexPath) as? DuringWorkoutResultSectionCell else { return UITableViewCell() }
         cell.selectionStyle = .none
-        cell.workoutSectionTableView.snp.updateConstraints {
-            $0.height.equalTo(49 * (cell.weightTrainingValue?.weightTrainingInfo.count ?? 1))
-            $0.top.equalTo(cell.workoutTitle.snp.bottom).offset(10)
-            $0.bottom.equalToSuperview().inset(20)
-            $0.leading.trailing.equalToSuperview().inset(11)
-        }
-        cell.configureCell(routineData?.weightTraining[indexPath.row] ?? WeightTraining(bodyPart: "", weightTraining: ""))
         cell.weightTrainingValue = routineData?.weightTraining[indexPath.row] ?? WeightTraining(bodyPart: "", weightTraining: "")
-        cell.completionHandler = { [weak self] value in
-            if value {
-                self?.workoutTableView.reloadData()
-                print("자꾸 호출?")
-            }
-        }
+        cell.configureCell(routineData?.weightTraining[indexPath.row] ?? WeightTraining(bodyPart: "", weightTraining: ""))
         return cell
     }
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return UITableView.automaticDimension
     }
-
     
 }


### PR DESCRIPTION
Close #324

### 📙 작업 내역

구현 내용 및 작업 했던 내역을 적어주세요.
- 1.운동 결과 UI 수정(tableview cell 내부에 tableview를 추가해서 해결)

``` swift
    func configureCell(_ weightTraining : WeightTraining) {
        workoutTitle.text = weightTraining.weightTraining
        weightTrainingValue = weightTraining
        
        workoutSectionTableView.snp.remakeConstraints {
            $0.height.equalTo(49 * weightTraining.weightTrainingInfo.count)
            $0.top.equalTo(workoutTitle.snp.bottom).offset(10)
            $0.bottom.equalToSuperview().inset(20)
            $0.leading.trailing.equalToSuperview().inset(11)
        }

    }
```

### 📸 스크린샷
<img src="https://github.com/workoutDone/WorkoutDone/assets/78063938/720ff8ab-6c09-451b-b522-d15e8737c2f9" width=300></img>

### 📋 체크리스트

- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?

### 📝 PR 특이 사항

PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.

- 특이 사항 없음
