### PR TITLE
#356 - [BugFix] 루틴 선택 뷰에서 루틴 만든 후 반영 안되는 버그 수정

### DIFF
--- a/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/Workout/WorkoutViewController.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/Workout/WorkoutViewController.swift
@@ -66,9 +66,15 @@ class WorkoutViewController : BaseViewController {
         
         title = "운동하기"
         view.backgroundColor = .colorFFFFFF
-        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+    
         myRoutines = routineViewModel.loadMyRoutine()
         selectedRoutines = Array(repeating: false, count: myRoutines.count)
+        
+        routineTableView.reloadData()
     }
     
     override func setupLayout() {
@@ -471,3 +477,5 @@ extension WorkoutViewController : MyRoutineDelegate {
         routineTableView.reloadData()
     }
 }
+
+


### PR DESCRIPTION
Close #356 

### 📙 작업 내역

구현 내용 및 작업 했던 내역을 적어주세요.
- 루틴 선택 뷰에서 루틴 만든 후 반영 안되는 버그 수정
```Swift
 override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)
    
    myRoutines = routineViewModel.loadMyRoutine() // 데이터 호출
    selectedRoutines = Array(repeating: false, count: myRoutines.count)
        
    routineTableView.reloadData()
}
 ```

### 📸 스크린샷
<img src="https://github.com/workoutDone/WorkoutDone/assets/98953443/ca2d54b7-1519-4042-ba29-b5d1e916bd38" width=300></img>

### 📋 체크리스트

- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?

### 📝 PR 특이 사항

PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.

- 
