### PR TITLE
#361 - [Refactor] 운동 삭제 방식 변경

### DIFF
--- a/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/Workout/Cell/WorkoutSequenceCell.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/Workout/Cell/WorkoutSequenceCell.swift
@@ -122,6 +122,5 @@ class WorkoutSequenceCell : UITableViewCell {
 
     @objc func removeButtonTapped() {
         delegate?.removeButtonTapped(forCell: self)
-        
     }
 }

--- a/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/Workout/EditButton.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/Workout/EditButton.swift
@@ -22,10 +22,8 @@ class EditButton: UIButton {
     
     func setAddOrRemoveButton() {
         self.backgroundColor = .colorF3F3F3
-        self.setTitle("추가/삭제", for: .normal)
         self.setTitleColor(.color363636, for: .normal)
         self.titleLabel?.font = .pretendard(.semiBold, size: 16)
-        
         self.layer.cornerRadius = 5
     }
     

--- a/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/Workout/WorkoutSequenceViewController.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/Workout/WorkoutSequenceViewController.swift
@@ -12,7 +12,7 @@ class WorkoutSequenceViewController: BaseViewController {
     var routineViewModel = RoutineViewModel()
     var selectedMyRoutineIndex : Int?
     
-    var isAddDeleteMode = false
+    var isAddDeleteMode : Bool = false
     
     var completionHandler : (() -> (Void))?
     
@@ -110,6 +110,7 @@ class WorkoutSequenceViewController: BaseViewController {
         title = "운동하기"
         
         editButton = EditButton(frame: CGRect(x: 0, y: 0, width: 80, height: 30))
+        editButton.setText("추가/삭제")
         editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
         let rightBarButton = UIBarButtonItem(customView: editButton)
         navigationItem.rightBarButtonItem = rightBarButton
@@ -180,7 +181,6 @@ extension WorkoutSequenceViewController : RemoveWorkoutDelegate {
         
         adjustTableViewHeight()
     }
-    
 }
 
 extension WorkoutSequenceViewController : UITableViewDelegate, UITableViewDataSource, UITableViewDragDelegate, UITableViewDropDelegate {

--- a/WorkoutDone/WorkoutDone/Sources/Presenter/RoutineScene/Routine/Cell/RoutineEditorCell.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/RoutineScene/Routine/Cell/RoutineEditorCell.swift
@@ -9,7 +9,13 @@ import UIKit
 import SnapKit
 import Then
 
+protocol RemoveWeightTrainingDelegate : AnyObject {
+    func removeButtonTapped(forCell cell: RoutineEditorCell)
+}
+
 class RoutineEditorCell: UITableViewCell {
+    weak var delegate : RemoveWeightTrainingDelegate?
+    
     private let bodyPartView = UIView().then {
         $0.layer.borderWidth = 1
         $0.layer.borderColor = UIColor.color7442FF.cgColor
@@ -30,6 +36,15 @@ class RoutineEditorCell: UITableViewCell {
     let editImage = UIImageView().then {
         $0.image = UIImage(named: "edit")
     }
+    
+    let removeButton = UIButton().then {
+        $0.layer.cornerRadius = 12
+        $0.backgroundColor = .colorFFEDF0
+    }
+    
+    let removeImage = UIImageView().then {
+        $0.image = UIImage(named: "remove")
+    }
 
     // MARK: - LIFECYCLE
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -44,6 +59,10 @@ class RoutineEditorCell: UITableViewCell {
         contentView.layer.borderColor = UIColor.colorC8B4FF.cgColor
         contentView.layer.cornerRadius = 8
         contentView.backgroundColor = .colorFFFFFF
+        
+        removeButton.isHidden = true
+        
+        removeButton.addTarget(self, action: #selector(removeButtonTapped), for: .touchUpInside)
         
     }
     
@@ -61,11 +80,12 @@ class RoutineEditorCell: UITableViewCell {
     
     // MARK: - ACTIONS
     func setupLayout() {
-        [bodyPartView, weightTrainingLabel, editImage].forEach {
+        [bodyPartView, weightTrainingLabel, editImage, removeButton].forEach {
             contentView.addSubview($0)
         }
 
         bodyPartView.addSubview(bodyPartLabel)
+        removeButton.addSubview(removeImage)
     }
     
     func setupConstraints() {
@@ -90,5 +110,20 @@ class RoutineEditorCell: UITableViewCell {
             $0.width.equalTo(15.5)
             $0.height.equalTo(9.3)
         }
+        
+        removeButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().offset(-10)
+            $0.width.height.equalTo(24)
+        }
+        
+        removeImage.snp.makeConstraints {
+            $0.centerX.centerY.equalToSuperview()
+            $0.width.height.equalTo(8)
+        }
+    }
+    
+    @objc func removeButtonTapped() {
+        delegate?.removeButtonTapped(forCell: self)
     }
 }


### PR DESCRIPTION
Close #361 

### 📙 작업 내역

구현 내용 및 작업 했던 내역을 적어주세요.
- 운동 밀어서 삭제 -> 버튼 삭제로 변경
```Swift
extension RoutineEditorViewController : RemoveWeightTrainingDelegate {
    func removeButtonTapped(forCell cell: RoutineEditorCell) {
        guard let indexPath = routineTableView.indexPath(for: cell) else { return }
        
        myWeightTraining.remove(at: indexPath.row)
        routineTableView.deleteRows(at: [indexPath], with: .fade)
    }
}
```
### 📸 스크린샷
<img src="https://github.com/workoutDone/WorkoutDone/assets/98953443/f8083ca1-d78e-473d-a6a3-1b88f3489fca" width=300></img>

### 📋 체크리스트

- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?

### 📝 PR 특이 사항

PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.

- 
