### PR TITLE
#371 - [BugFix] 루틴 운동 1개 일때 다음 운동 버튼 활성화 되는 문제 해결

### DIFF
--- a/WorkoutDone/WorkoutDone/Sources/Model/WorkOutDone/WeightTrainingInfo.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Model/WorkOutDone/WeightTrainingInfo.swift
@@ -13,7 +13,7 @@ class WeightTrainingInfo : Object {
     @Persisted dynamic var weight : Double?
     @Persisted dynamic var trainingCount : Int?
     
-    convenience init(setCount: Int, weight: Double, trainingCount: Int) {
+    convenience init(setCount: Int, weight: Double?, trainingCount: Int?) {
         self.init()
         self.setCount = setCount
         self.weight = weight

--- a/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringSetCells/DuringSetFooterCell.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringSetCells/DuringSetFooterCell.swift
@@ -12,7 +12,6 @@ protocol DuringSetFooterDelegate : AnyObject {
 }
 
 class DuringSetFooterCell : UITableViewHeaderFooterView {
-//    var handler: (() -> (Void))?
     var delegate : DuringSetFooterDelegate?
     static let footerViewID = "DuringSetFooterCell"
     
@@ -47,9 +46,7 @@ class DuringSetFooterCell : UITableViewHeaderFooterView {
         print("여기는?")
     }
     @objc func addWorkoutButtonTapped() {
-//        handler?()
         delegate?.addWorkoutButtonTapped()
-        print("?????????????")
     }
     
     private func setupLayout() {
@@ -59,11 +56,12 @@ class DuringSetFooterCell : UITableViewHeaderFooterView {
     }
     private func setupConstraints() {
         backView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.bottom.leading.trailing.equalToSuperview()
+            $0.top.equalToSuperview().inset(7)
         }
         dotLineImageView.snp.makeConstraints {
             $0.bottom.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(28)
+            $0.leading.trailing.equalToSuperview().inset(14)
             $0.height.equalTo(50)
         }
         addWorkoutButton.snp.makeConstraints {

--- a/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringSetCells/DuringSetTableViewCell.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringSetCells/DuringSetTableViewCell.swift
@@ -74,8 +74,8 @@ class DuringSetTableViewCell : UITableViewCell {
     }
     func configureCell(_ wegihtTrainingInfo : WeightTrainingInfo) {
         setLabel.text = "\(wegihtTrainingInfo.setCount)세트"
-        kgLabel.text = wegihtTrainingInfo.weight == 0 ? "-kg" : "\(wegihtTrainingInfo.weight ?? 0)kg"
-        countLabel.text = wegihtTrainingInfo.trainingCount == 0 ? "-회" : "\(wegihtTrainingInfo.trainingCount ?? 0)회"
+        kgLabel.text = wegihtTrainingInfo.weight == nil ? "-kg" : "\(wegihtTrainingInfo.weight ?? 0)kg"
+        countLabel.text = wegihtTrainingInfo.trainingCount == nil ? "-회" : "\(wegihtTrainingInfo.trainingCount ?? 0)회"
     }
     func checkCalisthenics(_ weightTraining : WeightTraining) {
         if Calisthenics.calisthenicsArray.contains(weightTraining.weightTraining) {

--- a/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringSetCells/DuringSetTableViewCell.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringSetCells/DuringSetTableViewCell.swift
@@ -37,7 +37,6 @@ class DuringSetTableViewCell : UITableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 7, left: 0, bottom: 7, right: 0))
     }
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -50,14 +49,15 @@ class DuringSetTableViewCell : UITableViewCell {
         super.init(coder: coder)
     }
     func setStyle() {
-        
+        contentView.backgroundColor = .colorF8F6FF
     }
     func setLayout() {
         contentView.addSubview(backView)
         backView.addSubviews(setLabel, kgLabel, countLabel)
         backView.snp.makeConstraints {
             $0.height.equalTo(50)
-            $0.leading.trailing.equalToSuperview().inset(28)
+            $0.top.bottom.equalToSuperview().inset(7)
+            $0.leading.trailing.equalToSuperview().inset(14)
         }
         setLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()

--- a/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringSetViewController.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringSetViewController.swift
@@ -151,6 +151,9 @@ extension DuringSetViewController : UITableViewDelegate, UITableViewDataSource, 
             footerView.delegate = self
             return footerView
         }
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return UIView()
+    }
     func addWorkoutButtonTapped() {
         addWeightTrainingInfoTrigger.onNext(())
         addWeightTrainingInfoIndexTrigger.onNext(weightTrainingArrayIndex)
@@ -173,6 +176,9 @@ extension DuringSetViewController : UITableViewDelegate, UITableViewDataSource, 
         return 64
     }
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return 64
+        return 57
+    }
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 7
     }
 }

--- a/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringWorkoutViewController.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/HomeScene/DuringWorkout/DuringWorkoutViewController.swift
@@ -48,7 +48,16 @@ final class DuringWorkoutViewController : BaseViewController {
     var weightTrainingInfoArrayIndex = 0
     var weightTrainingArrayCount = 0
     var weightTrainingInfoArrayCount = 0
-    var totalWorkoutCount : Double = 0
+    var totalWorkoutCount : Double = 0 {
+        didSet {
+            if totalWorkoutCount == 1 {
+                previousWorkoutButtonTitleLabel.textColor = .colorC8B4FF
+                previousWorkoutButton.isEnabled = false
+                nextWorkoutButtonTitleLabel.textColor = .colorC8B4FF
+                nextWorkoutButton.isEnabled = false
+            }
+        }
+    }
     var currentWorkoutCount : Double = 1
     
     

--- a/WorkoutDone/WorkoutDone/Sources/Presenter/RoutineScene/Routine/RoutineViewModel.swift
+++ b/WorkoutDone/WorkoutDone/Sources/Presenter/RoutineScene/Routine/RoutineViewModel.swift
@@ -88,7 +88,7 @@ struct RoutineViewModel {
     
     func setWeightTraining(_ weightTraining: [WeightTraining]) -> [WeightTraining] {
         for training in weightTraining {
-            training.weightTrainingInfo.append(objectsIn: [WeightTrainingInfo(setCount: 1, weight: 0, trainingCount: 0)])
+            training.weightTrainingInfo.append(objectsIn: [WeightTrainingInfo(setCount: 1, weight: nil, trainingCount: nil)])
         }
         return weightTraining
     }


### PR DESCRIPTION
Close #371

### 📙 작업 내역

구현 내용 및 작업 했던 내역을 적어주세요.
- 1.루틴 운동 1개 일때 다음 운동 버튼 활성화 되는 문제 해결

``` swift
    var totalWorkoutCount : Double = 0 {
        didSet {
            if totalWorkoutCount == 1 {
                previousWorkoutButtonTitleLabel.textColor = .colorC8B4FF
                previousWorkoutButton.isEnabled = false
                nextWorkoutButtonTitleLabel.textColor = .colorC8B4FF
                nextWorkoutButton.isEnabled = false
            }
        }
    }
```

### 📸 스크린샷
<img src="https://github.com/workoutDone/WorkoutDone/assets/78063938/58b2c349-d039-470c-8b53-2c075f7f9548" width=300></img>

### 📋 체크리스트

- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?

### 📝 PR 특이 사항

PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.

- 특이 사항 없음
